### PR TITLE
[nat] Allowing either CLI option or /var/run/secrets/kubernetes.io/serviceaccount/namespace detection

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -170,7 +170,6 @@ public class RunnerBuilder {
   private int p2pListenPort;
   private NatMethod natMethod = NatMethod.AUTO;
   private String natManagerServiceName;
-  private String natManagerServiceNamespace;
   private boolean natMethodFallbackEnabled;
   private EthNetworkConfig ethNetworkConfig;
   private EthstatsOptions ethstatsOptions;
@@ -342,17 +341,6 @@ public class RunnerBuilder {
    */
   public RunnerBuilder natManagerServiceName(final String natManagerServiceName) {
     this.natManagerServiceName = natManagerServiceName;
-    return this;
-  }
-
-  /**
-   * Add Nat manager service namespace.
-   *
-   * @param natManagerServiceNamespace the nat manager service namespace
-   * @return the runner builder
-   */
-  public RunnerBuilder natManagerServiceNamespace(final String natManagerServiceNamespace) {
-    this.natManagerServiceNamespace = natManagerServiceNamespace;
     return this;
   }
 
@@ -1172,7 +1160,7 @@ public class RunnerBuilder {
             new DockerNatManager(p2pAdvertisedHost, p2pListenPort, jsonRpcConfiguration.getPort()));
       case KUBERNETES:
         return Optional.of(
-            new KubernetesNatManager(natManagerServiceName, natManagerServiceNamespace));
+            new KubernetesNatManager(natManagerServiceName));
       case NONE:
       default:
         return Optional.empty();

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -31,7 +31,6 @@ import static org.hyperledger.besu.metrics.MetricsProtocol.PROMETHEUS;
 import static org.hyperledger.besu.metrics.prometheus.MetricsConfiguration.DEFAULT_METRICS_PORT;
 import static org.hyperledger.besu.metrics.prometheus.MetricsConfiguration.DEFAULT_METRICS_PUSH_PORT;
 import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAME;
-import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAMESPACE;
 
 import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.Runner;
@@ -1581,15 +1580,6 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             "The `--Xnat-kube-service-name` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-name"
                 + " or select the KUBERNETES mode (via --nat-method=KUBERNETES)");
       }
-
-      if (!unstableNatOptions
-          .getNatManagerServiceNamespace()
-          .equals(DEFAULT_BESU_SERVICE_NAMESPACE)) {
-        throw new ParameterException(
-            this.commandLine,
-            "The `--Xnat-kube-service-namespace` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-namespace"
-                + " or select the KUBERNETES mode (via --nat-method=KUBERNETES)");
-      }
     }
     if (natMethod.equals(NatMethod.AUTO) && !unstableNatOptions.getNatMethodFallbackEnabled()) {
       throw new ParameterException(
@@ -2265,7 +2255,6 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .p2pEnabled(p2pEnabled)
             .natMethod(natMethod)
             .natManagerServiceName(unstableNatOptions.getNatManagerServiceName())
-            .natManagerServiceNamespace(unstableNatOptions.getNatManagerServiceNamespace())
             .natMethodFallbackEnabled(unstableNatOptions.getNatMethodFallbackEnabled())
             .discovery(peerDiscoveryEnabled)
             .ethNetworkConfig(ethNetworkConfig)

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/NatOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/NatOptions.java
@@ -30,14 +30,6 @@ public class NatOptions {
           "Specify the name of the service that will be used by the nat manager in Kubernetes. (default: ${DEFAULT-VALUE})")
   private String natManagerServiceName = DEFAULT_BESU_SERVICE_NAME;
 
-  @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"}) // PicoCLI requires non-final Strings.
-  @CommandLine.Option(
-      hidden = true,
-      names = {"--Xnat-kube-service-namespace"},
-      description =
-          "Specify the namespace of the service that will be used by the nat manager in Kubernetes. (default: ${DEFAULT-VALUE})")
-  private String natManagerServiceNamespace = DEFAULT_BESU_SERVICE_NAMESPACE;
-
   @CommandLine.Option(
       hidden = true,
       names = {"--Xnat-method-fallback-enabled"},
@@ -65,15 +57,6 @@ public class NatOptions {
    */
   public String getNatManagerServiceName() {
     return natManagerServiceName;
-  }
-
-  /**
-   * Gets nat manager service namespace.
-   *
-   * @return the nat manager service namespace
-   */
-  public String getNatManagerServiceNamespace() {
-    return natManagerServiceNamespace;
   }
 
   /**

--- a/nat/src/main/java/org/hyperledger/besu/nat/kubernetes/KubernetesNatManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/kubernetes/KubernetesNatManager.java
@@ -24,6 +24,10 @@ import org.hyperledger.besu.nat.core.exception.NatInitializationException;
 import org.hyperledger.besu.nat.kubernetes.service.KubernetesServiceType;
 import org.hyperledger.besu.nat.kubernetes.service.LoadBalancerBasedDetector;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -53,6 +57,8 @@ public class KubernetesNatManager extends AbstractNatManager {
 
   public static final String DEFAULT_BESU_SERVICE_NAMESPACE = "besu";
 
+  private static final Path KUBERNETES_NAMESPACE_FILE = Paths.get("var/run/secrets/kubernetes.io/serviceaccount/namespace");
+
   private String internalAdvertisedHost;
   private final String besuServiceName;
   private final String besuServiceNamespace;
@@ -62,12 +68,17 @@ public class KubernetesNatManager extends AbstractNatManager {
    * Instantiates a new Kubernetes nat manager.
    *
    * @param besuServiceName the besu service name
-   * @param besuServiceNamespace the besu service namespace
    */
-  public KubernetesNatManager(final String besuServiceName, final String besuServiceNamespace) {
+  public KubernetesNatManager(final String besuServiceName) {
     super(NatMethod.KUBERNETES);
     this.besuServiceName = besuServiceName;
-    this.besuServiceNamespace = besuServiceNamespace;
+    String ns = DEFAULT_BESU_SERVICE_NAMESPACE;
+    try {
+      ns = Files.readString(KUBERNETES_NAMESPACE_FILE);
+    } catch (IOException ex) {
+      LOG.info("Failed to determine namespace via serviceaccount folder");
+    }
+    this.besuServiceNamespace = ns;
   }
 
   @Override


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Builds off of https://github.com/hyperledger/besu/pull/6088 and avoids the need for the new experimental namespace option.

If running within Kubernetes, Services create Endpoints for Pods in the same Namespace. So it is unnecessary to assume a Besu Pod will need to detect a LoadBalancer Service in a separate Namespace from itself (which is why it's great we're avoiding need access to all Namespaces bc that violates least privileges).

However, the Kubernetes docs mention:
> You want to point your Service to a Service in a different [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces) or on another cluster
https://kubernetes.io/docs/concepts/services-networking/service/#services-without-selectors

It's debatable if LoadBalancer Services even work in such a scenario, and feels simpler to just simply state that is unsupported and therefore Besu only looks for Services in its same Namespace.

As a result, we can rely on this file that _should_ always be present since ServiceAccount is always mounted to a Pod. And we fallback to the default if not.

## Fixed Issue(s)

Addresses concerns from https://github.com/hyperledger/besu/pull/6088#issuecomment-2236016637.