### PR TITLE
Fix previous hotfix which pinned library to an old version

### DIFF
--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -96,7 +96,7 @@ dependencies {
 
     api 'io.kubernetes:client-java:21.0.1-legacy'
     // Temporarily locking in to avoid https://github.com/netplex/json-smart-v2/issues/240
-    api 'net.minidev:json-smart:2.4.2'
+    api 'net.minidev:json-smart:2.5.1'
 
     api 'io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0:2.9.0-alpha'
     api 'io.opentelemetry.proto:opentelemetry-proto:1.3.2-alpha'


### PR DESCRIPTION
## PR description
Pin `net.minidev:json-smart` to the correct version.

Issue https://github.com/netplex/json-smart-v2/issues/240 on one of Besu's pre-reqs led to Besu pinning the library to `2.4.2`. This version has `HIGH` CVEs in. This was to work around an issue with maven metadata.

Pinning to the version Besu was already using means the build doesn't hit the maven-metadata issue, but also doesn't use an old version with CVEs in.