### PR TITLE
Ensure block height manager is restarted when BFT coordinator is

### DIFF
--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftMiningCoordinator.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftMiningCoordinator.java
@@ -115,6 +115,7 @@ public class BftMiningCoordinator implements MiningCoordinator, BlockAddedObserv
         LOG.debug("Interrupted while waiting for BftProcessor to stop.", e);
         Thread.currentThread().interrupt();
       }
+      eventHandler.stop();
       bftExecutors.stop();
     }
   }

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/statemachine/BaseBftController.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/statemachine/BaseBftController.java
@@ -81,6 +81,13 @@ public abstract class BaseBftController implements BftEventHandler {
   }
 
   @Override
+  public void stop() {
+    if (started.compareAndSet(true, false)) {
+      LOG.debug("Stopped current height manager");
+    }
+  }
+
+  @Override
   public void handleMessageEvent(final BftReceivedMessageEvent msg) {
     final MessageData data = msg.getMessage().getData();
     if (!duplicateMessageTracker.hasSeenMessage(data)) {

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/statemachine/BftEventHandler.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/statemachine/BftEventHandler.java
@@ -25,6 +25,9 @@ public interface BftEventHandler {
   /** Start. */
   void start();
 
+  /** Stop. */
+  void stop();
+
   /**
    * Handle message event.
    *


### PR DESCRIPTION
## PR description
There appears to be an issue with BFT nodes stopping their BFT coordinator while they sync with existing nodes. I've recreated the issue locally and I'm pretty confident the fix is the correct one. An OSS issue/PR will follow.

## Fixed Issue(s)
This is intended to resolve https://github.com/kaleido-io/kaleido-planning/issues/4522