### PR TITLE
close rocksdb transaction correctly with bonsai (#9467)

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/BonsaiWorldStateKeyValueStorage.java
@@ -322,11 +322,13 @@ public class BonsaiWorldStateKeyValueStorage extends PathBasedWorldStateKeyValue
     @Override
     public void commitTrieLogOnly() {
       trieLogStorageTransaction.commit();
+      composedWorldStateTransaction.close();
     }
 
     @Override
     public void commitComposedOnly() {
       composedWorldStateTransaction.commit();
+      trieLogStorageTransaction.close();
     }
 
     @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/worldview/PathBasedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/worldview/PathBasedWorldState.java
@@ -307,6 +307,11 @@ public abstract class PathBasedWorldState
         public void rollback() {
           // no-op
         }
+
+        @Override
+        public void close() {
+          // no-op
+        }
       };
 
   protected static final SegmentedKeyValueStorageTransaction noOpSegmentedTx =
@@ -330,6 +335,11 @@ public abstract class PathBasedWorldState
 
         @Override
         public void rollback() {
+          // no-op
+        }
+
+        @Override
+        public void close() {
           // no-op
         }
       };

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '5BI+4JAKgBsTClKWIeF86C3kS/RVT3Cdwyju/HydR9o='
+  knownHash = 'ACVfXtQZDPbvDrHz43Rigj8ZLzph7Pnp0q8z11gzpjA='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/KeyValueStorageTransaction.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/KeyValueStorageTransaction.java
@@ -48,4 +48,7 @@ public interface KeyValueStorageTransaction {
 
   /** Reset the transaction to a state prior to any operations being queued. */
   void rollback();
+
+  /** close the transaction */
+  void close();
 }

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/SegmentedKeyValueStorageTransaction.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/SegmentedKeyValueStorageTransaction.java
@@ -52,4 +52,7 @@ public interface SegmentedKeyValueStorageTransaction {
 
   /** Reset the transaction to a state prior to any operations being queued. */
   void rollback();
+
+  /** close the transaction */
+  void close();
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransaction.java
@@ -114,7 +114,8 @@ public class RocksDBTransaction implements SegmentedKeyValueStorageTransaction {
     }
   }
 
-  private void close() {
+  @Override
+  public void close() {
     innerTx.close();
     options.close();
   }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueSnapshot.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueSnapshot.java
@@ -297,5 +297,10 @@ public class RocksDBColumnarKeyValueSnapshot
         public void rollback() {
           // no-op
         }
+
+        @Override
+        public void close() {
+          // no-op
+        }
       };
 }

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/KeyValueStorageTransactionValidatorDecorator.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/KeyValueStorageTransactionValidatorDecorator.java
@@ -69,4 +69,12 @@ public class KeyValueStorageTransactionValidatorDecorator implements KeyValueSto
     active = false;
     transaction.rollback();
   }
+
+  @Override
+  public void close() {
+    checkState(active, "Cannot close a completed transaction.");
+    checkState(!isClosed.get(), "Cannot invoke close() on a closed storage.");
+    active = false;
+    transaction.close();
+  }
 }

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LimitedInMemoryKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LimitedInMemoryKeyValueStorage.java
@@ -195,6 +195,11 @@ public class LimitedInMemoryKeyValueStorage implements KeyValueStorage {
 
     @Override
     public void rollback() {
+      close();
+    }
+
+    @Override
+    public void close() {
       updatedValues.clear();
       removedKeys.clear();
     }

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedInMemoryKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedInMemoryKeyValueStorage.java
@@ -388,6 +388,11 @@ public class SegmentedInMemoryKeyValueStorage
 
     @Override
     public void rollback() {
+      close();
+    }
+
+    @Override
+    public void close() {
       updatedValues.clear();
       removedKeys.clear();
     }

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorageAdapter.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorageAdapter.java
@@ -173,5 +173,10 @@ public class SegmentedKeyValueStorageAdapter implements KeyValueStorage {
     public void rollback() {
       segmentedTransaction.rollback();
     }
+
+    @Override
+    public void close() {
+      segmentedTransaction.close();
+    }
   }
 }

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorageTransactionValidatorDecorator.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorageTransactionValidatorDecorator.java
@@ -71,4 +71,12 @@ public class SegmentedKeyValueStorageTransactionValidatorDecorator
     active = false;
     transaction.rollback();
   }
+
+  @Override
+  public void close() {
+    checkState(active, "Cannot close a completed transaction.");
+    checkState(!isClosed.get(), "Cannot invoke close() on a closed storage.");
+    active = false;
+    transaction.close();
+  }
 }


### PR DESCRIPTION
## PR description
Pulls in commit 7ac38c6f4ec09f7a186b4e7b3a7244bbf4301507 from OSS PR https://github.com/hyperledger/besu/pull/9467

This  commit has been run using build https://github.com/kaleido-io/firefly-enterprise/actions/runs/20712511910 for the last month and shown to be successful. See slack thread https://kaleidoio.slack.com/archives/CNY6MQ30E/p1767608179026249?thread_ts=1766092078.870159&cid=CNY6MQ30E for discussion.
