### PR TITLE
estimate gas support for 7702 (#9939)

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CodeDelegationParameterDeserializer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CodeDelegationParameterDeserializer.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Deserializes code delegation entries for call parameters, accepting either signed delegations or
@@ -51,6 +52,12 @@ public class CodeDelegationParameterDeserializer extends JsonDeserializer<CodeDe
 
     if (hasAuthority) {
       return mapper.treeToValue(node, SimulationCodeDelegation.class);
+    }
+
+    // Normalize yParity to v for CodeDelegation deserialization.
+    // EIP-7702 allows both field names; if only yParity is provided, map it to v.
+    if (node.hasNonNull("yParity") && !node.hasNonNull("v") && node.isObject()) {
+      ((ObjectNode) node).set("v", node.get("yParity"));
     }
 
     return mapper.treeToValue(node, org.hyperledger.besu.ethereum.core.CodeDelegation.class);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/CallParameterTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/CallParameterTest.java
@@ -167,6 +167,47 @@ public class CallParameterTest {
   }
 
   @Test
+  public void signedAuthorizationListWithYParity() throws JsonProcessingException {
+    final String json =
+        """
+        {
+          "authorizationList": [
+            {
+              "chainId": "0x1",
+              "address": "0x6b7879a5d747e30a3adb37a9e41c046928fce933",
+              "nonce": "0x82",
+              "yParity": "0x1",
+              "r": "0x462a70678128d9dd8f5b8010aaecddda1ba9ad767f0807c341f38d4dcb7eb893",
+              "s": "0x645f7afd51a86bafe8939c8498fc89769918a38213859843ad7b19ffd4273a48"
+            }
+          ]
+        }
+        """;
+
+    final CallParameter callParameter = objectMapper.readValue(json, CallParameter.class);
+
+    assertThat(callParameter.getCodeDelegationAuthorizations())
+        .hasSize(1)
+        .first()
+        .satisfies(
+            auth -> {
+              assertThat(auth.chainId()).isEqualTo(BigInteger.ONE);
+              assertThat(auth.address().getBytes().toHexString())
+                  .isEqualTo("0x6b7879a5d747e30a3adb37a9e41c046928fce933");
+              assertThat(auth.nonce()).isEqualTo(130L);
+              assertThat(auth.v()).isEqualTo((byte) 0x1);
+              assertThat(auth.r())
+                  .isEqualTo(
+                      new BigInteger(
+                          "462a70678128d9dd8f5b8010aaecddda1ba9ad767f0807c341f38d4dcb7eb893", 16));
+              assertThat(auth.s())
+                  .isEqualTo(
+                      new BigInteger(
+                          "645f7afd51a86bafe8939c8498fc89769918a38213859843ad7b19ffd4273a48", 16));
+            });
+  }
+
+  @Test
   public void unsignedAuthorizationListSerializationRoundtrip() throws JsonProcessingException {
     final String json =
         """


### PR DESCRIPTION
Cherry picking OSS PR https://github.com/besu-eth/besu/pull/9939 onto our Besu 26.2.0 release.

I've tested with a viem EIP 7702 delegation before and after:

Before fix:

```
const authorization = await client.signAuthorization({
    contractAddress: DELEGATE_ADDRESS,
    executor: 'self',
  });

...

  const hash = await client.sendTransaction({
    to: account.address, // Usually EOAs send to themselves to activate delegation
    authorizationList: [authorization],
    // gas: 900000, <<-- With this commented out, the EIP 7702 transaction fails because gas estimation fails
  });
```

```
Estimate Gas Arguments:
  from:                  0xA7A488E933780Ba835C888BB0363F7605a01CD5a
  to:                    0xA7A488E933780Ba835C888BB0363F7605a01CD5a
  maxFeePerGas:          0 gwei
  maxPriorityFeePerGas:  0 gwei
  nonce:                 0
 
Request Arguments:
  from:  0xA7A488E933780Ba835C888BB0363F7605a01CD5a
  to:    0xA7A488E933780Ba835C888BB0363F7605a01CD5a

Details: Invalid call params
Version: viem@2.48.0
    at getTransactionError (file:///Users/mwhitehead/node_modules/viem/_esm/utils/errors/getTransactionError.js:11:12)
    at sendTransaction (file:///Users/mwhitehead/node_modules/viem/_esm/actions/wallet/sendTransaction.js:210:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async delegate (file:///Users/mwhitehead/local-eip7702.mjs:40:16) {
  cause: EstimateGasExecutionError: Invalid parameters were provided to the RPC method.
```

After fix (same viem script with gas commented out):

```
Preparing EIP-7702 Delegation...
{
  address: '0xB0152F70383Fa032f331C000F628BB6DFE51492F',
  chainId: 1337,
  nonce: 1,
  r: '0x200cb9dd319b344c22f8bc1c9fd5dc4eb3f41dd5509e97b5f8a8acb8d5dcd3a3',
  s: '0x40b80b74aa1a4d6fea58f0110492cf6740c3229a2100389b30aa4621c0aecbec',
  v: 27n,
  yParity: 0
}
Transaction sent! Hash: 0x8ab2c64e1c811aee8c91613ecfd4770de40460839f501412e6198f3571bd526e
```

and `eth_getCode` test against the EOA correctly returns the delegation contract + prefix:

```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": "0xef0100b0152f70383fa032f331c000f628bb6dfe51492f".  <<-- delegated contract address
}
```