### PR TITLE
Backport OSS PR 10611 to `26.2.0` to address `prevrandao` bug in BFT

### DIFF
--- a/acceptance-tests/tests/contracts/PrevRandaoContract.sol
+++ b/acceptance-tests/tests/contracts/PrevRandaoContract.sol
@@ -1,0 +1,36 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+pragma solidity >=0.8.19;
+
+// compile with:
+// solc PrevRandaoContract.sol --bin --abi --optimize --overwrite -o .
+// then create web3j wrappers with:
+// web3j generate solidity -b ./generated/PrevRandaoContract.bin -a ./generated/PrevRandaoContract.abi -o ../../../../../ -p org.hyperledger.besu.tests.web3j.generated
+
+// Emits the prevrandao value as an indexed log topic when logPrevRandao() is called.
+// Used to verify that all QBFT nodes agree on the prevrandao value during block execution:
+// if the proposer and validators use different prevrandao values the log topics differ,
+// the bloom filter differs, and the receipts root mismatches — causing the block to be
+// rejected by validators and the chain to stall.
+contract PrevRandaoContract {
+    event PrevRandaoValue(uint256 indexed value);
+
+    uint256 public latestPrevRandao;
+
+    function logPrevRandao() public {
+        latestPrevRandao = block.prevrandao;
+        emit PrevRandaoValue(block.prevrandao);
+    }
+}

--- a/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/bft/ibft2/PrevRandaoContractIbft2AcceptanceTest.java
+++ b/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/bft/ibft2/PrevRandaoContractIbft2AcceptanceTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.bft.ibft2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
+import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
+import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
+import org.hyperledger.besu.tests.web3j.generated.PrevRandaoContract;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
+
+/**
+ * Acceptance test for IBFT2 blocks that contain transactions reading block.prevrandao.
+ *
+ * <p>In BFT consensus the block proposer executes transactions using a ProcessableBlockHeader whose
+ * mixHashOrPrevRandao field is Bytes32.ZERO, then overwrites the final block header's mixHash with
+ * BftHelpers.EXPECTED_MIX_HASH. Validator nodes receive the final block and re-execute transactions
+ * using EXPECTED_MIX_HASH as the PREVRANDAO value. When a contract emits an indexed log whose value
+ * is block.prevrandao the log topics differ between proposer and validator, causing a bloom-filter
+ * / receipts-root mismatch that causes validators to reject the block and the chain to stall.
+ */
+public class PrevRandaoContractIbft2AcceptanceTest extends AcceptanceTestBase {
+
+  private BesuNode validator1;
+  private BesuNode validator2;
+  private BesuNode validator3;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    validator1 = besu.createIbft2Node("validator1", false, DataStorageFormat.FOREST);
+    validator2 = besu.createIbft2Node("validator2", false, DataStorageFormat.FOREST);
+    validator3 = besu.createIbft2Node("validator3", false, DataStorageFormat.FOREST);
+    cluster.start(validator1, validator2, validator3);
+  }
+
+  /**
+   * Deploys PrevRandaoContract on a 3-node IBFT2 cluster and calls logPrevRandao(), which emits
+   * PrevRandaoValue(block.prevrandao) as an indexed event. The test verifies that a contract which
+   * uses block.prevrandao doesn't create a block which fails to validate.
+   */
+  @Test
+  public void blockWithPrevRandaoLogShouldBeAcceptedByAllValidators() throws Exception {
+    final PrevRandaoContract contract =
+        validator1.execute(contractTransactions.createSmartContract(PrevRandaoContract.class));
+
+    final TransactionReceipt receipt = contract.logPrevRandao().send();
+
+    assertThat(receipt).isNotNull();
+    assertThat(receipt.isStatusOK())
+        .as(
+            "logPrevRandao() transaction must be accepted; if it fails the chain has stalled due "
+                + "to receipts-root mismatch between proposer (prevrandao=Bytes32.ZERO) and "
+                + "validators (prevrandao=EXPECTED_MIX_HASH)")
+        .isTrue();
+
+    // Verify the chain continues to produce blocks beyond the one containing the transaction.
+    cluster.verify(blockchain.minimumHeight(receipt.getBlockNumber().longValue() + 1, 30));
+  }
+}

--- a/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptanceqbft/jsonrpc/PrevRandaoContractAcceptanceTest.java
+++ b/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptanceqbft/jsonrpc/PrevRandaoContractAcceptanceTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptanceqbft.jsonrpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
+import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
+import org.hyperledger.besu.tests.web3j.generated.PrevRandaoContract;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
+
+/**
+ * Acceptance test for QBFT blocks that contain transactions reading block.prevrandao.
+ *
+ * <p>In BFT consensus the block proposer executes transactions using a ProcessableBlockHeader whose
+ * mixHashOrPrevRandao field is Bytes32.ZERO, then overwrites the final block header's mixHash with
+ * BftHelpers.EXPECTED_MIX_HASH. Validator nodes receive the final block and re-execute transactions
+ * using EXPECTED_MIX_HASH as the PREVRANDAO value. When a contract emits an indexed log whose value
+ * is block.prevrandao the log topics differ between proposer and validator, causing a bloom-filter
+ * / receipts-root mismatch that causes validators to reject the block and the chain to stall.
+ */
+public class PrevRandaoContractAcceptanceTest extends AcceptanceTestBase {
+
+  private BesuNode validator1;
+  private BesuNode validator2;
+  private BesuNode validator3;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    validator1 = besu.createQbftNode("validator1");
+    validator2 = besu.createQbftNode("validator2");
+    validator3 = besu.createQbftNode("validator3");
+    cluster.start(validator1, validator2, validator3);
+  }
+
+  /**
+   * Deploys PrevRandaoContract on a 3-node QBFT cluster and calls logPrevRandao(), which emits
+   * PrevRandaoValue(block.prevrandao) as an indexed event. The test verifies that a contract which
+   * uses block.prevrandao doesn't create a block which fails to validate.
+   */
+  @Test
+  public void blockWithPrevRandaoLogShouldBeAcceptedByAllValidators() throws Exception {
+    final PrevRandaoContract contract =
+        validator1.execute(contractTransactions.createSmartContract(PrevRandaoContract.class));
+
+    final TransactionReceipt receipt = contract.logPrevRandao().send();
+
+    assertThat(receipt).isNotNull();
+    assertThat(receipt.isStatusOK())
+        .as(
+            "logPrevRandao() transaction must be accepted; if it fails the chain has stalled due "
+                + "to receipts-root mismatch between proposer (prevrandao=Bytes32.ZERO) and "
+                + "validators (prevrandao=EXPECTED_MIX_HASH)")
+        .isTrue();
+
+    // Verify the chain continues to produce blocks beyond the one containing the transaction.
+    cluster.verify(blockchain.minimumHeight(receipt.getBlockNumber().longValue() + 1, 30));
+  }
+}

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftBlockCreator.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftBlockCreator.java
@@ -35,6 +35,8 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import java.util.Collections;
 import java.util.Optional;
 
+import org.apache.tuweni.bytes.Bytes32;
+
 /** The Bft block creator. */
 // This class is responsible for creating a block without committer seals (basically it was just
 // too hard to coordinate with the state machine).
@@ -85,7 +87,16 @@ public class BftBlockCreator extends AbstractBlockCreator {
     if (protocolSpec.getWithdrawalsProcessor().isPresent()) {
       return createEmptyWithdrawalsBlock(timestamp, parentHeader);
     } else {
-      return createBlock(Optional.empty(), Optional.empty(), timestamp, parentHeader);
+      return createBlock(
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(Bytes32.wrap(BftHelpers.EXPECTED_MIX_HASH.getBytes())),
+          Optional.empty(),
+          Optional.empty(),
+          timestamp,
+          true,
+          parentHeader);
     }
   }
 
@@ -116,7 +127,11 @@ public class BftBlockCreator extends AbstractBlockCreator {
         Optional.empty(),
         Optional.empty(),
         Optional.of(Collections.emptyList()),
+        Optional.of(Bytes32.wrap(BftHelpers.EXPECTED_MIX_HASH.getBytes())),
+        Optional.empty(),
+        Optional.empty(),
         timestamp,
+        true,
         parentHeader);
   }
 


### PR DESCRIPTION
## PR description

See OSS PR https://github.com/besu-eth/besu/pull/10611. This is a backport of that fix to the `kaleido-besu-release-26.2.0` stream

## Fixed Issue(s)
See https://github.com/besu-eth/besu/issues/10610