### PR TITLE
Fix CVE-2025-67030: bump plexus-utils 3.5.1 -> 3.6.1 (25.8.0)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,6 +229,8 @@ configure(allprojects - project(':platform')) {
     resolutionStrategy.capabilitiesResolution.withCapability('org.bouncycastle:bcpkix-jdk18on') {
       selectHighestVersion()
     }
+    // CVE-2025-67030: transitive via maven-artifact
+    resolutionStrategy.force 'org.codehaus.plexus:plexus-utils:3.6.1'
 
     // transitive versions conflict with io.protocols.tuweni, prefer ours
     exclude group: 'io.tmio', module: 'tuweni-bytes'


### PR DESCRIPTION
## CVE Fix

Forces `org.codehaus.plexus:plexus-utils` from 3.5.1 to 3.6.1 via Gradle `resolutionStrategy.force`.

**CVE:** CVE-2025-67030 (HIGH)
**Package:** org.codehaus.plexus:plexus-utils
**Installed:** 3.5.1 (transitive via maven-artifact 3.9.9)
**Fixed:** 3.6.1
**Image affected:** kaleido-node-besu

Renovate cannot reach this transitive dependency; agent fix using resolution strategy. Verification-metadata.xml regenerated.